### PR TITLE
WIP: Remove need for Ivy/Maven Spark JARs; enables providing JARs directly 

### DIFF
--- a/modules/core/src/main/scala/org/apache/spark/sql/ammonitesparkinternals/AmmoniteSparkSessionBuilder.scala
+++ b/modules/core/src/main/scala/org/apache/spark/sql/ammonitesparkinternals/AmmoniteSparkSessionBuilder.scala
@@ -218,13 +218,13 @@ class AmmoniteSparkSessionBuilder
 
     val jars = (baseJars ++ sessionJars).distinct
 
-    println("Getting spark JARs")
-    val sparkJars = SparkDependencies.sparkJars(interpApi.repositories(), Nil) // interpApi.profiles().sorted)
+//    println("Getting spark JARs")
+//    val sparkJars = SparkDependencies.sparkJars(interpApi.repositories(), Nil) // interpApi.profiles().sorted)
 
     if (isYarn())
-      config("spark.yarn.jars", sparkJars.mkString(","))
+      config("spark.yarn.jars", jars.mkString(","))
 
-    config("spark.jars", jars.filterNot(sparkJars.toSet).mkString(","))
+    config("spark.jars", jars.mkString(","))
 
     val classServer = new AmmoniteClassServer(
       host(),


### PR DESCRIPTION
As mentioned in discussions with @alexarchambault, right now the solution described in https://github.com/almond-sh/almond/issues/227 for getting ammonite-spark to work with a provided class-path does not work. 

If one provides these jars already in the classpath, it raises an error when it tries to find them on maven or in a local ivy directory.

This PR eliminates the codepath that causes that failure at the cost of disabling the ability to get these dependencies on the fly from maven/a local ivy repository.

I'm not sure how to best implement the flag for telling the class to not search for the provided spark. 

If one passes an optional argument to `builder` then one can no longer override the upstream builder script. 

Suggestions for how to implement this as an optional feature are welcome — I'll update my PR accordingly.