### PR TITLE
Add Fix for REPL Class Server URL Issue

### DIFF
--- a/modules/core/src/main/scala/org/apache/spark/sql/ammonitesparkinternals/AmmoniteSparkSessionBuilder.scala
+++ b/modules/core/src/main/scala/org/apache/spark/sql/ammonitesparkinternals/AmmoniteSparkSessionBuilder.scala
@@ -303,7 +303,7 @@ class AmmoniteSparkSessionBuilder
     )
     classServerOpt = Some(classServer)
 
-    config("spark.repl.class.uri", classServer.uri.toString)
+    config("spark.repl.class.uri", s"${classServer.uri.toString}/")
 
     if (!options0.contains("spark.ui.port"))
       config("spark.ui.port", AmmoniteClassServer.availablePortFrom(4040).toString)


### PR DESCRIPTION
- Added a trailing forward slash to the value of property 'spark.repl.class.uri' in order to fix broken deserialization of lambdas in Spark executors observed when running Spark 3.2.0 jobs that contain transformations