### PR TITLE
Add Fix for REPL Server URI Issue

### DIFF
--- a/modules/core/src/main/scala/org/apache/spark/sql/ammonitesparkinternals/AmmoniteClassServer.scala
+++ b/modules/core/src/main/scala/org/apache/spark/sql/ammonitesparkinternals/AmmoniteClassServer.scala
@@ -63,7 +63,17 @@ final class AmmoniteClassServer(host: String, bindTo: String, port: Int, frames:
   def stop(): Unit =
     server.stop()
 
-  def uri = new URI(s"http://$host:$port")
+  def uri = {
+    val sparkBinaryVersion = {
+      org.apache.spark.SPARK_VERSION
+        .split('.')
+        .take(2)
+        .mkString("")
+        .toInt
+    }
+    val uriStr = if (sparkBinaryVersion >= 32) s"http://$host:$port/" else s"http://$host:$port"
+    new URI(uriStr)
+  }
 
 }
 


### PR DESCRIPTION
For Spark versions >= 3.2.x, added a trailing forward slash to the value of property 'spark.repl.class.uri' in order to fix broken deserialization of lambdas in Spark executors observed when running Spark 3.2.0 jobs that contain Spark transformations