### PR TITLE
Favor spark.repl.class.outputDir over spark.repl.class.uri

### DIFF
--- a/modules/core/src/main/scala/org/apache/spark/sql/ammonitesparkinternals/AmmoniteSparkSessionBuilder.scala
+++ b/modules/core/src/main/scala/org/apache/spark/sql/ammonitesparkinternals/AmmoniteSparkSessionBuilder.scala
@@ -5,8 +5,8 @@ import java.net.{InetAddress, URI, URL, URLClassLoader}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
 
-import ammonite.repl.api.ReplAPI
 import ammonite.interp.api.InterpAPI
+import ammonite.repl.api.ReplAPI
 import coursierapi.Dependency
 import org.apache.spark.SparkContext
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}

--- a/modules/tests/src/main/scala/ammonite/spark/fromammonite/TestRepl.scala
+++ b/modules/tests/src/main/scala/ammonite/spark/fromammonite/TestRepl.scala
@@ -54,20 +54,25 @@ class TestRepl {
   val sess0 = new SessionApiImpl(frames)
 
   var currentLine = 0
+  val interpParams = Interpreter.Parameters(
+    printer = printer0,
+    storage = storage,
+    wd = os.pwd,
+    colors = Ref(Colors.BlackWhite),
+    verboseOutput = true,
+    alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("ammonite/spark/amm-test-dependencies.txt")
+  )
   val interp = try {
     new Interpreter(
-      compilerBuilder = ammonite.compiler.CompilerBuilder,
-      parser = ammonite.compiler.Parsers,
-      printer = printer0,
-      storage = storage,
-      wd = os.pwd,
-      colors = Ref(Colors.BlackWhite),
-      verboseOutput = true,
+      compilerBuilder = ammonite.compiler.CompilerBuilder(
+        outputDir = Some(os.temp.dir(prefix = "amm-spark-tests").toNIO)
+      ),
+      parser = () => ammonite.compiler.Parsers,
       getFrame = () => frames().head,
       createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
       replCodeWrapper = codeWrapper,
       scriptCodeWrapper = codeWrapper,
-      alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("ammonite/spark/amm-test-dependencies.txt")
+      parameters = interpParams
     )
 
   }catch{ case e: Throwable =>

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -10,7 +10,7 @@ object Deps {
     def scala213 = "2.13.10"
   }
 
-  private def ammoniteVersion = "2.5.8"
+  private def ammoniteVersion = "3.0.0-M0-14-c12b6a59"
   def ammoniteCompiler = ("com.lihaoyi" % "ammonite-compiler" % ammoniteVersion).cross(CrossVersion.full)
   def ammoniteReplApi = ("com.lihaoyi" % "ammonite-repl-api" % ammoniteVersion).cross(CrossVersion.full)
   def ammoniteRepl = ("com.lihaoyi" % "ammonite-repl" % ammoniteVersion).cross(CrossVersion.full)


### PR DESCRIPTION
The former is used by spark-repl since Spark… 2.something I think. It relies on some Spark RPC stuff to work, which is more likely to work fine in tight network environments.