### PR TITLE
Check log4j2 log file when using Spark 3

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -261,6 +261,7 @@ class AlmondSpark(val crossScalaVersion: String) extends CrossSbtModule with Amm
   def compileIvyDeps = super.compileIvyDeps() ++ Agg(
     Deps.ammoniteReplApi,
     Deps.jsoniterScalaMacros,
+    Deps.log4j2,
     Deps.scalaKernelApi,
     Deps.sparkSql(scalaVersion())
   )

--- a/modules/almond-spark/src/main/scala/org/apache/spark/sql/almondinternals/Log4j2File.scala
+++ b/modules/almond-spark/src/main/scala/org/apache/spark/sql/almondinternals/Log4j2File.scala
@@ -1,0 +1,26 @@
+package org.apache.spark.sql.almondinternals
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.{Appender, Logger => Log4jLogger}
+import org.apache.logging.log4j.core.appender.FileAppender
+
+import java.io.File
+
+import scala.collection.JavaConverters._
+
+object Log4j2File {
+
+  def logFile(clazz: Class[_]): Option[File] = {
+
+    def appenders(log: Log4jLogger): Stream[Appender] =
+      if (log == null)
+        Stream()
+      else
+        log.getAppenders.asScala.values.toStream #::: appenders(log.getParent)
+
+    appenders(LogManager.getLogger(clazz).asInstanceOf[Log4jLogger]).collectFirst {
+      case fa: FileAppender => new File(fa.getFileName)
+    }
+  }
+
+}

--- a/modules/almond-spark/src/main/scala/org/apache/spark/sql/almondinternals/Log4jFile.scala
+++ b/modules/almond-spark/src/main/scala/org/apache/spark/sql/almondinternals/Log4jFile.scala
@@ -1,0 +1,24 @@
+package org.apache.spark.sql.almondinternals
+
+import org.apache.log4j.{Category, Logger, RollingFileAppender}
+
+import java.io.File
+
+import scala.collection.JavaConverters._
+
+object Log4jFile {
+
+  def logFile(clazz: Class[_]): Option[File] = {
+
+    def appenders(log: Category): Stream[Any] =
+      if (log == null)
+        Stream()
+      else
+        log.getAllAppenders.asScala.toStream #::: appenders(log.getParent)
+
+    appenders(Logger.getLogger(clazz)).collectFirst {
+      case rfa: RollingFileAppender => new File(rfa.getFile)
+    }
+  }
+
+}

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -20,6 +20,7 @@ object Deps {
     ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:${Versions.jsoniterScala}"
   def jsoniterScalaMacros =
     ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:${Versions.jsoniterScala}"
+  def log4j2         = ivy"org.apache.logging.log4j:log4j-core:2.17.2"
   def scalaKernelApi = ivy"sh.almond:::scala-kernel-api:0.13.4"
   def sparkSql(sv: String) = {
     val ver =


### PR DESCRIPTION
When `logsInDeveloperConsole(true)` is called on `NotebookSparkSessionBuilder`, it tries to find the location of the log4j file, watches it, and send its content to the browser console.

This makes sure that the log4j2 file (rather than just log4j) can be found.