### PR TITLE
Disable jsoniter-scala updates via .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,4 @@
-updates.ignore = [ { groupId = "org.apache.spark", artifactId = "spark-sql" } ]
+updates.ignore = [
+  { groupId = "org.apache.spark", artifactId = "spark-sql" },
+  { groupId = "com.github.plokhotnyuk.jsoniter-scala" }
+]


### PR DESCRIPTION
Newer versions of jsoniter-scala don't support Java 8. So we're staying on 2.13.5 for now.