### PR TITLE
Improve Progress Bar Rendering and Cleanup

### DIFF
--- a/modules/almond-spark/src/main/scala/org/apache/spark/sql/almondinternals/ProgressSparkListener.scala
+++ b/modules/almond-spark/src/main/scala/org/apache/spark/sql/almondinternals/ProgressSparkListener.scala
@@ -87,7 +87,7 @@ final class ProgressSparkListener(
     if (progress)
       Try {
         val elem = stageElem(stageCompleted.stageInfo.stageId)
-        elem.allDone()
+        elem.stageDone()
       }
 
   override def onTaskStart(taskStart: SparkListenerTaskStart): Unit =
@@ -121,7 +121,7 @@ private[almondinternals] class ProgressBarUpdater(
   }
 
   private val pool = {
-    val executor = new ScheduledThreadPoolExecutor(1, threadFactory)
+    val executor = new ScheduledThreadPoolExecutor(5, threadFactory)
     executor.setKeepAliveTime(1L, TimeUnit.MINUTES)
     executor.allowCoreThreadTimeOut(true)
     executor
@@ -131,12 +131,12 @@ private[almondinternals] class ProgressBarUpdater(
     lazy val polling: ScheduledFuture[_] = pool.scheduleAtFixedRate(
       () => {
         elem.update()
-        if (elem.allDone0)
+        if (elem.stageDone0)
           polling.cancel(false)
       },
       0,
-      1,
-      TimeUnit.SECONDS
+      250,
+      TimeUnit.MILLISECONDS
     )
     polling
   }


### PR DESCRIPTION
The objective of these changes is to 
- remove job titles when their associated progress bars are removed for 'keep'==false to 
  prevent left-over job titles from mangling the output
- to improve the progress bar rendering for multi-stage and short-lived Spark jobs

Code Changes:
- In Method StageElem::update
  * Included stage title in erasure section
  * Moved erasure section to update section to allow very last update to be rendered
- In class 'StageElem', changed member var name from 'allDone0' to 'stageDone0'
- In val ProgressBarUpdater::pool, changed corePoolSize arg from 1 to 5 to allow concurrent rendering and updates of stages belonging to multi-stage jobs
- In method ProgressBarUpdater::asyncPollUpdatesFor, changed update period from 1 second to 250 milliseconds for more granular progress bar updates.