### PR TITLE
Don't bump log4j-core via Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,5 @@
 updates.ignore = [
   { groupId = "org.apache.spark", artifactId = "spark-sql" },
-  { groupId = "com.github.plokhotnyuk.jsoniter-scala" }
+  { groupId = "com.github.plokhotnyuk.jsoniter-scala" },
+  { groupId = "org.apache.logging.log4j", artifactId = "log4j-core" }
 ]


### PR DESCRIPTION
It's only a compile-time dependency. Better depend on an old version of it, so that we don't inadvertently rely on newer APIs.