### PR TITLE
Don't print spurious messages in JupyterLab when creating SparkSession

### DIFF
--- a/modules/almond-spark/src/main/scala/org/apache/spark/sql/almondinternals/NotebookSparkSessionBuilder.scala
+++ b/modules/almond-spark/src/main/scala/org/apache/spark/sql/almondinternals/NotebookSparkSessionBuilder.scala
@@ -64,7 +64,6 @@ class NotebookSparkSessionBuilder(implicit
 
     try {
       sendLogOpt = logFileOpt.map { f =>
-        println("See your browser developer console for detailed spark logs.")
         SendLog.start(f)
       }
 


### PR DESCRIPTION
This gets rid of "See your browser developer console for detailed spark logs." when the logs can't be sent to the browser (only possible when we can run arbitrary Javascript, and this requires the Jupyter classic API for now), and of "Javascript Error: Jupyter is not defined" (when the Jupyter classic API isn't available)